### PR TITLE
fix parsing of stopbit option

### DIFF
--- a/mbrtu.c
+++ b/mbrtu.c
@@ -427,9 +427,12 @@ static inline int parse_bus_parameter_options (int argc, char *argv[])
 		break;
 
 	    case 's':
-		switch ((conn->stopbits = (uint8_t) optarg[0])) {
-		    case 1:
-		    case 2:
+		switch (optarg[0]) {
+		    case '1':
+                        conn->stopbits = 1;
+                        break;
+		    case '2':
+                        conn->stopbits = 2;
 			break;
 		    default:
 			IF_N_QUIET fprintf (stderr, "Couldn't parse number stop bits: \"%s\"!\n", optarg);


### PR DESCRIPTION
this patch fixes broken handling of the stopbit option. Simply casting optarg[0] to uint makes mbrtu think that is should use 48 stop bits, resulting in "couldn't parse number stop bits: 1".